### PR TITLE
feat: Embed the Lua source in the Swift binary

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
+        "state": {
+          "branch": null,
+          "revision": "8f4d2753f0e4778c76d5f05ad16c74f707390531",
+          "version": "1.2.3"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -7,7 +7,7 @@ let package = Package(
     name: "Tilt",
     platforms: [
         .iOS(.v15),
-        .macOS(.v12)
+        .macOS(.v13)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
@@ -16,9 +16,15 @@ let package = Package(
             targets: [
                 "Tilt",
             ]),
+        .plugin(
+            name: "EmbedLuaPlugin",
+            targets: [
+                "EmbedLuaPlugin"
+            ]),
     ],
     dependencies: [
         .package(path: "LuaSwift"),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.1.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -33,12 +39,27 @@ let package = Package(
             dependencies: [
                 .product(name: "Lua", package: "LuaSwift")
             ],
-            resources: [
-                .copy("src"),
+            plugins: [
+                "EmbedLuaPlugin",
             ]),
         .testTarget(
             name: "tilt-test",
-            dependencies: ["Tilt"]
-        )
+            dependencies: ["Tilt", "SourceModel"]
+        ),
+        .target(
+            name: "SourceModel",
+            dependencies: []),
+        .executableTarget(
+            name: "embedlua",
+            dependencies: [
+                "SourceModel",
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            ]),
+        .plugin(
+            name: "EmbedLuaPlugin",
+            capability: .buildTool(),
+            dependencies: [
+                "embedlua",
+            ]),
     ]
 )

--- a/Plugins/EmbedLuaPlugin/EmbedLuaPlugin.swift
+++ b/Plugins/EmbedLuaPlugin/EmbedLuaPlugin.swift
@@ -1,0 +1,42 @@
+// Copyright (c) 2023 Tom Sutcliffe, Jason Morley
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import PackagePlugin
+
+@main
+struct EmbedLuaPlugin: BuildToolPlugin {
+    func createBuildCommands(context: PluginContext, target: Target) async throws -> [Command] {
+        guard let target = target as? SourceModuleTarget else {
+            return []
+        }
+        let inputPath = target.directory
+        let inputFiles = target.sourceFiles(withSuffix: "lua")
+            .map { $0.path }
+        let outputPath = context.pluginWorkDirectory.appending("LuaSource.swift")
+        return [.buildCommand(displayName: "Generating \(outputPath.lastComponent) from lua source",
+                              executable: try context.tool(named: "embedlua").path,
+                              arguments: inputFiles + [
+                                "--source-root", inputPath,
+                                "--output", outputPath,
+                              ],
+                              inputFiles: inputFiles,
+                              outputFiles: [outputPath])]
+    }
+}

--- a/Sources/SourceModel/Source.swift
+++ b/Sources/SourceModel/Source.swift
@@ -1,0 +1,47 @@
+// Copyright (c) 2023 Tom Sutcliffe, Jason Morley
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+public enum SourceModelError: Error {
+    case corrupt
+}
+
+public struct Source: Codable {
+
+    public let files: [String: Data]
+
+    public init(files: [String: Data]) {
+        self.files = files
+    }
+
+    public init(base64EncodedString: String) throws {
+        guard let data = Data(base64Encoded: base64EncodedString) else {
+            throw SourceModelError.corrupt
+        }
+        let decoder = JSONDecoder()
+        self = try decoder.decode(Source.self, from: data)
+    }
+
+    public func base64EncodedString() throws -> String {
+        return try JSONEncoder().encode(self).base64EncodedString()
+    }
+
+}

--- a/Sources/Tilt/Example.swift
+++ b/Sources/Tilt/Example.swift
@@ -1,0 +1,32 @@
+// Copyright (c) 2023 Tom Sutcliffe, Jason Morley
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+public struct Example {
+
+    public static func printLuaFilenames() {
+        let source = LuaSource.default
+        for (name, _) in source.files {
+            print(name)
+        }
+    }
+
+}

--- a/Sources/Tilt/TiltEnvironment.swift
+++ b/Sources/Tilt/TiltEnvironment.swift
@@ -36,7 +36,8 @@ public class TiltEnvironment {
 
     public init() {
         L = LuaState(libraries: .all)
-        L.setRequireRoot(Bundle.module.url(forResource: "src", withExtension: nil)!.path, displayPrefix: "Tilt/")
+        // Obviously this no longer works as we don't have a bundle anymore.
+//        L.setRequireRoot(Bundle.module.url(forResource: "src", withExtension: nil)!.path, displayPrefix: "Tilt/")
         L.getglobal("require")
         try! L.pcall("templater")
     }

--- a/Sources/embedlua/Command.swift
+++ b/Sources/embedlua/Command.swift
@@ -1,0 +1,76 @@
+// Copyright (c) 2023 Tom Sutcliffe, Jason Morley
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import ArgumentParser
+import Foundation
+
+import SourceModel
+
+@main
+struct Command: ParsableCommand {
+    
+    @Argument
+    var sources: [String]
+
+    @Option
+    var sourceRoot: String
+
+    @Option
+    var output: String
+
+    func run() throws {
+
+        // Convert the sources to relative URLs so that, should we need to, we can reference their full relative path
+        // in the source tree. Ideally we'd pull these relative paths out in the Package Manager Plugin, but it doesn't
+        // seem to provide any way to do it, so we're doing it here instead.
+        let sourceRoot = sourceRoot.ensuringSuffix("/")
+        let sourceRootURL = URL(filePath: sourceRoot, directoryHint: .isDirectory)
+        let sourceURLs = try sources.map { source in
+            guard source.hasPrefix(sourceRoot) else {
+                throw EmbedLuaError.general("Source '\(source)' is not within source root '\(sourceRoot)'.")
+            }
+            let relativePath = String(source.dropFirst(sourceRoot.count))
+            return URL(filePath: relativePath, relativeTo: sourceRootURL)
+        }
+
+        let outputURL = URL(filePath: output)
+        let files = try sourceURLs
+            .reduce(into: [String: Data]()) { partialResult, sourceURL in
+                partialResult[sourceURL.relativePath] = try Data(contentsOf: sourceURL)
+            }
+        let source = Source(files: files)
+        let base64EncodedString = try source.base64EncodedString()
+
+        let contents = """
+import SourceModel
+
+struct LuaSource {
+
+    static let `default`: Source = {
+        return try! Source(base64EncodedString: \"\(base64EncodedString)\")
+    }()
+
+}
+"""
+        let data = contents.data(using: .utf8)
+        try data?.write(to: outputURL)
+    }
+
+}

--- a/Sources/embedlua/EmbedLuaError.swift
+++ b/Sources/embedlua/EmbedLuaError.swift
@@ -1,0 +1,25 @@
+// Copyright (c) 2023 Tom Sutcliffe, Jason Morley
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+enum EmbedLuaError: Error {
+    case general(String)
+}

--- a/Sources/embedlua/Extensions/String.swift
+++ b/Sources/embedlua/Extensions/String.swift
@@ -1,0 +1,32 @@
+// Copyright (c) 2023 Tom Sutcliffe, Jason Morley
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+extension String {
+
+    func ensuringSuffix(_ suffix: String) -> String {
+        guard !self.hasSuffix(suffix) else {
+            return self
+        }
+        return self + suffix
+    }
+
+}

--- a/Sources/tilt-cli/main.swift
+++ b/Sources/tilt-cli/main.swift
@@ -9,15 +9,18 @@ import Foundation
 import Lua
 import CLua
 
+import Tilt
+
 let L = LuaState(libraries: .all)
+Example.printLuaFilenames()
 
-if CommandLine.arguments.count != 2 {
-    fatalError("Syntax: templuater <path/to/templater.lua>")
-}
-let templaterPath = CommandLine.arguments[1]
-
-let x = luaL_dofile(L, templaterPath)
-if x != 0 {
-    let err = L.tostring(1) ?? "nil"
-    fatalError("ret = \(x) err=\(err)")
-}
+//if CommandLine.arguments.count != 2 {
+//    fatalError("Syntax: templuater <path/to/templater.lua>")
+//}
+//let templaterPath = CommandLine.arguments[1]
+//
+//let x = luaL_dofile(L, templaterPath)
+//if x != 0 {
+//    let err = L.tostring(1) ?? "nil"
+//    fatalError("ret = \(x) err=\(err)")
+//}


### PR DESCRIPTION
Unfortunately, using a Bundle to embed the source means the Tilt module can't really be used in a standalone binary. This [incomplete] change attempts to address that by providing a mechanism to embed Lua sources in the binary. It's very much a proof of concept right now--hopefully we can actually compile the code at build time and perhaps move the Swift Package Manager Build Plugin (wow, that's a name) down into the Lua package.

Although this looks like a lot of code change, it's fairly simple once you wrap your head around the crazy-ass way Swift wants to do things.

Some highlights:

- This introduces three new targets:
  - `EmbedLuaPlugin` -- a build plugin that runs in the context of the package manager at build time, finds all the *.lua files in the target, and calls 'embedlua' to generate a 'LuaSource.swift' file which is made available to the target
  - `embedlua` -- a command line executable that takes a set of input Lua files, reads their contents, and writes out a Swift file containing a base64 encoded struct of their relative paths and contents
  - `SourceModel` -- an incredibly lightweight module containing the `Source` struct to make it easy to share encoding and decoding between Tilt and embedlua

This change, as is, does break Tilt--it necessarily comments out the bundle source loading in `TiltEnvironment` as there's no longer a bundle, and it hacks tilt-cli to demonstrate that Lua source file loading actually works.

For completeness, the generated 'LuaSource.swift' looks something like this:

```swift
import SourceModel

struct LuaSource {

    static let `default`: Source = {
        return try! Source(base64EncodedString: "eyJmaWxlcyI6eyJzcmNcL3RlbXBsYXRlci5sdWEiO....lYUW9jbVYwTENBaVhHNGlLUXBsYm1RSyJ9fQ==")
    }()

}
```