### PR TITLE
fix: Catch up to LuaSwift with improved Linux support

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -10,7 +10,7 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build:
+  build-macos:
 
     runs-on: macos-13
 

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -16,11 +16,26 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Switch Xcode
       run: sudo xcode-select -s /Applications/Xcode_14.3.1.app
+    - name: Build
+      run: swift build -v
+    - name: Run tests
+      run: swift test -v
+
+  build-linux:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+    - uses: swift-actions/setup-swift@v2
     - name: Build
       run: swift build -v
     - name: Run tests


### PR DESCRIPTION
This change catches up to the latest version of LuaSwift (thank you @tomsci) which adds improved support for type wrangling on Linux Swift. To ensure we're always testing Linux as well, it also adds Linux builds using the GitHub Actions ubuntu-latest runner. To avoid ambiguity, this renames the 'build' job to 'build-macos'.